### PR TITLE
#3 error objects

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": [["@babel/preset-env", { "shippedProposals": true }]],
+  "plugins": ["@babel/plugin-proposal-class-properties"]
+}

--- a/src/errors/errors.js
+++ b/src/errors/errors.js
@@ -1,0 +1,44 @@
+/**
+ * Contains simple functions which correspond to an error code.
+ * Each error code function accepts parameters which are
+ * interpolated into the associated error message for specific
+ * error codes in order to provide more specific detail. Also a
+ * generic helper method to return an errorObject.
+ */
+
+/**
+ * Error code functions which relate an error code and
+ * message
+ */
+
+/**
+ * Generic error codes
+ */
+export const ERROR_RUNTIME = errorMessage =>
+  `Error: Unexpected runtime error occurred. ${errorMessage}`;
+export const ERROR_UNKNOWN = method => `Error: During ${method}, an unknown error occured.`;
+
+/**
+ * Generic network error codes
+ */
+export const ERROR_INCORRECT_URL = method =>
+  `Error: During ${method}, incorrect base URL. HTTP CODE: 404`;
+export const ERROR_UNEXPECTED_RESPONSE = (method, status) =>
+  `Error: During ${method}, an unexpected response ${status} was received.`;
+export const ERROR_NETWORK = method =>
+  `Error: During ${method}, the request did not reach the server.`;
+export const ERROR_AUTHENTICATION = method =>
+  `Error: During ${method}, an authentication error occurred. HTTP CODE: 401`;
+
+/**
+ * Simple method to return a formatted error object.
+ * @param {ERROR_CODE}            function An error code function
+ * @param {...optionalParameters} String Optional parameters for the ERROR_CODE function
+ */
+export function errorObject(ERROR_CODE, ...optionalParameters) {
+  const { name: code } = ERROR_CODE;
+  return {
+    code,
+    message: ERROR_CODE(...optionalParameters),
+  };
+}

--- a/src/tests/errors/errorObjects.test.js
+++ b/src/tests/errors/errorObjects.test.js
@@ -9,7 +9,7 @@
 import { CORRECT_ERROR_OBJECTS, ERROR_TEST_DATA } from '../testData/errors';
 import { errorObject } from '../../errors/errors';
 
-test('Runtime error object should be equal', () => {
+test('All error objects should be deeply equal', () => {
   Object.entries(ERROR_TEST_DATA).forEach(([errorCode, testData]) => {
     const returnValue = errorObject(...testData);
     expect(returnValue).toEqual(CORRECT_ERROR_OBJECTS[errorCode]);

--- a/src/tests/errors/errorObjects.test.js
+++ b/src/tests/errors/errorObjects.test.js
@@ -1,0 +1,17 @@
+/**
+ * Tests to ensure error object return objects are correct
+ * and consistent.
+ *
+ * Each test should use the `errorObject` method in errors/errors.js
+ * and each error code function should have it's own test.
+ */
+
+import { CORRECT_ERROR_OBJECTS, ERROR_TEST_DATA } from '../testData/errors';
+import { errorObject } from '../../errors/errors';
+
+test('Runtime error object should be equal', () => {
+  Object.entries(ERROR_TEST_DATA).forEach(([errorCode, testData]) => {
+    const returnValue = errorObject(...testData);
+    expect(returnValue).toEqual(CORRECT_ERROR_OBJECTS[errorCode]);
+  });
+});

--- a/src/tests/testData/errors.js
+++ b/src/tests/testData/errors.js
@@ -1,3 +1,11 @@
+/**
+ * Test data for error objects.
+ * Any new error code added should have a new entry
+ * added into both CORRECT_ERROR_OBJECTS and
+ * ERROR_TEST_DATA, which will then have tests run
+ * on it.
+ */
+
 import {
   ERROR_RUNTIME,
   ERROR_UNKNOWN,

--- a/src/tests/testData/errors.js
+++ b/src/tests/testData/errors.js
@@ -1,0 +1,44 @@
+import {
+  ERROR_RUNTIME,
+  ERROR_UNKNOWN,
+  ERROR_INCORRECT_URL,
+  ERROR_UNEXPECTED_RESPONSE,
+  ERROR_NETWORK,
+  ERROR_AUTHENTICATION,
+} from '../../errors/errors';
+
+export const CORRECT_ERROR_OBJECTS = {
+  ERROR_RUNTIME: {
+    code: 'ERROR_RUNTIME',
+    message: 'Error: Unexpected runtime error occurred. error message',
+  },
+  ERROR_UNKNOWN: {
+    code: 'ERROR_UNKNOWN',
+    message: 'Error: During method, an unknown error occured.',
+  },
+  ERROR_INCORRECT_URL: {
+    code: 'ERROR_INCORRECT_URL',
+    message: 'Error: During method, incorrect base URL. HTTP CODE: 404',
+  },
+  ERROR_UNEXPECTED_RESPONSE: {
+    code: 'ERROR_UNEXPECTED_RESPONSE',
+    message: 'Error: During method, an unexpected response status was received.',
+  },
+  ERROR_NETWORK: {
+    code: 'ERROR_NETWORK',
+    message: 'Error: During method, the request did not reach the server.',
+  },
+  ERROR_AUTHENTICATION: {
+    code: 'ERROR_AUTHENTICATION',
+    message: 'Error: During method, an authentication error occurred. HTTP CODE: 401',
+  },
+};
+
+export const ERROR_TEST_DATA = {
+  ERROR_RUNTIME: [ERROR_RUNTIME, 'error message'],
+  ERROR_UNKNOWN: [ERROR_UNKNOWN, 'method'],
+  ERROR_INCORRECT_URL: [ERROR_INCORRECT_URL, 'method'],
+  ERROR_UNEXPECTED_RESPONSE: [ERROR_UNEXPECTED_RESPONSE, 'method', 'status'],
+  ERROR_NETWORK: [ERROR_NETWORK, 'method'],
+  ERROR_AUTHENTICATION: [ERROR_AUTHENTICATION, 'method'],
+};


### PR DESCRIPTION
Fixes #3 

- Adds a generic error object helper function which will create objects to be returned with error codes and details about what's gone wrong
- Adds generic error codes, more to be added with more testing of the Tupaia API
- Adds simple error object test data
- Adds simple error object tests
- Tests passing

Also adds a `.babelrc` as I forgot in the initial setup