### PR TITLE
#9 test connection method

### DIFF
--- a/src/api/ApiConfigs.js
+++ b/src/api/ApiConfigs.js
@@ -15,16 +15,20 @@ export default class ApiConfigs {
    * body, a response is returned indicating which objects were
    * rejected, with a 400 response.
    */
-  static surveyResponse = ({ username, password, data = [] }) => ({
-    ...this.BASE_CONFIG,
-    method: 'POST',
-    url: '/surveyResponse',
-    headers: { 'content-type': 'application/json' },
-    validateStatus: status => status === 200 || status === 400,
-    data: [...data],
-    auth: {
-      username,
-      password,
-    },
-  });
+  static surveyResponse = ({ credentials = {}, data = [] }) => {
+    const { baseURL, username, password } = credentials;
+    return {
+      ...this.BASE_CONFIG,
+      baseURL,
+      method: 'POST',
+      url: '/surveyResponse',
+      headers: { 'content-type': 'application/json' },
+      validateStatus: status => status === 200 || status === 400,
+      data: [...data],
+      auth: {
+        username,
+        password,
+      },
+    };
+  };
 }

--- a/src/errors/errorLookup.js
+++ b/src/errors/errorLookup.js
@@ -42,6 +42,9 @@ const ERROR_LOOKUP = {
   surveyResponse: {
     ...BASE_ERROR_LOOKUP_TABLE,
   },
+  testConnection: {
+    ...BASE_ERROR_LOOKUP_TABLE,
+  },
 };
 
 /**

--- a/src/requests/index.js
+++ b/src/requests/index.js
@@ -1,3 +1,4 @@
 /* eslint-disable import/prefer-default-export */
 
 export { surveyResponse } from './surveyResponse';
+export { testConnection } from './testConnection';

--- a/src/requests/surveyResponse.js
+++ b/src/requests/surveyResponse.js
@@ -18,7 +18,7 @@ import getErrorObject from '../errors/errorLookup';
 
 export async function surveyResponse({ credentials = {}, data = [] }) {
   // Fetch the HTTP config with required settings, timeouts etc.
-  let apiConfig = ApiConfigs.surveyResponse({ ...credentials, data });
+  let apiConfig = ApiConfigs.surveyResponse({ credentials, data });
   // Function scope return object to handle different block scopes.
   let returnObject;
   // Attempt to push the data to Tupaia, anything other than success is

--- a/src/requests/testConnection.js
+++ b/src/requests/testConnection.js
@@ -1,0 +1,31 @@
+/* eslint-disable import/prefer-default-export */
+import Axios from 'axios';
+
+import ApiConfigs from '../api/ApiConfigs';
+import getErrorObject from '../errors/errorLookup';
+
+/**
+ * Request method for testing that a connection can be established
+ * with the Tupaia server, using the surveyResponse endpoint.
+ * @param {Object}    RequestData Request data
+ * @param {Object}    RequestData.credentials Basic authentication details
+ * @param {String}    RequestData.credentials.username
+ * @param {String}    RequestData.credentials.password
+ * @param {String}    RequestData.credentials.baseURL
+ * @returns {Boolean} True if a connection can be established, false otherwise.
+ */
+
+export async function testConnection({ credentials = {} }) {
+  // Fetch the HTTP config with required settings, timeouts etc.
+  const apiConfig = ApiConfigs.surveyResponse({ credentials });
+  try {
+    // send an empty bodied request to the surveyResponse endpoint,
+    // If we receive a response, we can reach the server. Otherwise,
+    // axios will throw an error which will be caught and sent back
+    // as an unsuccesful call.
+    await Axios(apiConfig);
+    return true;
+  } catch (error) {
+    throw getErrorObject(error, 'testConnection');
+  }
+}

--- a/src/tests/testData/apiConfigs.js
+++ b/src/tests/testData/apiConfigs.js
@@ -10,9 +10,9 @@ export const API_CONFIGS = ['surveyResponse'];
 
 export const API_CONFIG_INPUT_OUTPUT = {
   surveyResponse: {
-    input: { username: 'Sussol', password: 'Sussol' },
+    input: { credentials: { username: 'Sussol', password: 'Sussol', baseURL: 'url' } },
     output: {
-      baseURL: 'https://dev-api.tupaia.org/v2',
+      baseURL: 'url',
       timeout: 10000,
       method: 'POST',
       url: '/surveyResponse',


### PR DESCRIPTION
fixes #9 

Simple method which just sends an empty request to the Tupaia survey to test if it can be reached.

Also slightly changes the `surveyResponse` endpoints api config to also accept a baseURL as a parameter

